### PR TITLE
Draw markers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 
 FILE(GLOB_RECURSE SOURCE_FILES ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
-add_library(${PROJECT_NAME} ${SOURCE_FILES})
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBS})
 
 add_executable(stag_main ${PROJECT_SOURCE_DIR}/src/main.cpp)

--- a/include/stag/Drawer.h
+++ b/include/stag/Drawer.h
@@ -29,8 +29,11 @@ public:
 	// draws quads
 	void drawQuads(const string& path, cv::Mat image, const vector<Quad> &quads);
 
-	// draws markers
+	// draws markers to file
 	void drawMarkers(const string& path, cv::Mat image, const vector<Marker> &markers);
+
+	// draws markers to image
+	cv::Mat drawMarkers(cv::Mat image, const vector<Marker> &markers);
 
 	// draws refined markers and their ellipses
 	void drawEllipses(const string& path, cv::Mat image, const vector<Marker> &markers);

--- a/include/stag/Stag.h
+++ b/include/stag/Stag.h
@@ -40,6 +40,8 @@ public:
 	Stag(int libraryHD = 15, int errorCorrection = 7, bool inKeepLogs = false);
 	size_t detectMarkers(const cv::Mat& inImage);
 	void logResults(string path = "");
+	cv::Mat drawMarkers();
+	vector<Marker> getMarkerList() const;
 };
 
 } // namespace stag

--- a/src/Drawer.cpp
+++ b/src/Drawer.cpp
@@ -109,42 +109,44 @@ void Drawer::drawQuads(const string& path, Mat image, const vector<Quad> &quads)
 			cv::line(bgrMat, cv::Point(corners[j].x, corners[j].y), cv::Point(corners[(j + 1) % 4].x, corners[(j + 1) % 4].y), cv::Scalar(50, 255, 50), 2, CV_AA);
 
 			}
-	vector<int> compressionParams = { CV_IMWRITE_PNG_COMPRESSION, 0 };
-	cv::imwrite(path, bgrMat, compressionParams);
 }
 
+cv::Mat Drawer::drawMarkers(Mat image, const vector<Marker> &markers) {
+  Mat greyMat = image.clone();
+  Mat bgrMat;
+  cv::cvtColor(greyMat, bgrMat, CV_GRAY2BGR);
+
+  for (int i = 0; i < markers.size(); i++)
+  {
+    vector<Point2d> corners = markers[i].corners;
+    Point2d center = markers[i].center;
+
+    cv::circle(bgrMat, cv::Point(corners[0].x, corners[0].y), 6, cv::Scalar(255, 255, 255), -1, CV_AA);
+    for (int j = 0; j < 4; j++)
+      cv::line(bgrMat, cv::Point(corners[j].x, corners[j].y), cv::Point(corners[(j + 1) % 4].x, corners[(j + 1) % 4].y), cv::Scalar(255, 255, 255), 1, CV_AA);
+
+    cv::circle(bgrMat, cv::Point(corners[0].x, corners[0].y), 5, cv::Scalar(50, 255, 50), -1, CV_AA);
+    for (int j = 0; j < 4; j++)
+      cv::line(bgrMat, cv::Point(corners[j].x, corners[j].y), cv::Point(corners[(j + 1) % 4].x, corners[(j + 1) % 4].y), cv::Scalar(50, 255, 50), 1, CV_AA);
+
+    cv::circle(bgrMat, cv::Point(corners[1].x, corners[1].y), 5, cv::Scalar(255, 255, 0), -1, CV_AA);
+    cv::circle(bgrMat, cv::Point(corners[2].x, corners[2].y), 5, cv::Scalar(255, 0, 0), -1, CV_AA);
+    cv::circle(bgrMat, cv::Point(corners[3].x, corners[3].y), 5, cv::Scalar(255, 0, 255), -1, CV_AA);
+
+    cv::circle(bgrMat, cv::Point(center.x, center.y), 6, cv::Scalar(255, 255, 255), -1, CV_AA);
+    cv::circle(bgrMat, cv::Point(center.x, center.y), 5, cv::Scalar(50, 255, 50), -1, CV_AA);
+
+    cv::putText(bgrMat, std::to_string(markers[i].id), center, cv::FONT_HERSHEY_DUPLEX, 2, cv::Scalar(255, 255, 255), 5, CV_AA);
+    cv::putText(bgrMat, std::to_string(markers[i].id), center, cv::FONT_HERSHEY_DUPLEX, 2, cv::Scalar(50, 50, 255), 2, CV_AA);
+  }
+  return bgrMat;
+}
 
 void Drawer::drawMarkers(const string& path, Mat image, const vector<Marker> &markers)
 {
-	Mat greyMat = image.clone();
-	Mat bgrMat;
-	cv::cvtColor(greyMat, bgrMat, CV_GRAY2BGR);
-
-	for (int i = 0; i < markers.size(); i++)
-	{
-		vector<Point2d> corners = markers[i].corners;
-		Point2d center = markers[i].center;
-
-		cv::circle(bgrMat, cv::Point(corners[0].x, corners[0].y), 6, cv::Scalar(255, 255, 255), -1, CV_AA);
-		for (int j = 0; j < 4; j++)
-			cv::line(bgrMat, cv::Point(corners[j].x, corners[j].y), cv::Point(corners[(j + 1) % 4].x, corners[(j + 1) % 4].y), cv::Scalar(255, 255, 255), 1, CV_AA);
-
-		cv::circle(bgrMat, cv::Point(corners[0].x, corners[0].y), 5, cv::Scalar(50, 255, 50), -1, CV_AA);
-		for (int j = 0; j < 4; j++)
-			cv::line(bgrMat, cv::Point(corners[j].x, corners[j].y), cv::Point(corners[(j + 1) % 4].x, corners[(j + 1) % 4].y), cv::Scalar(50, 255, 50), 1, CV_AA);
-
-        cv::circle(bgrMat, cv::Point(corners[1].x, corners[1].y), 5, cv::Scalar(255, 255, 0), -1, CV_AA);
-        cv::circle(bgrMat, cv::Point(corners[2].x, corners[2].y), 5, cv::Scalar(255, 0, 0), -1, CV_AA);
-        cv::circle(bgrMat, cv::Point(corners[3].x, corners[3].y), 5, cv::Scalar(255, 0, 255), -1, CV_AA);
-
-		cv::circle(bgrMat, cv::Point(center.x, center.y), 6, cv::Scalar(255, 255, 255), -1, CV_AA);
-		cv::circle(bgrMat, cv::Point(center.x, center.y), 5, cv::Scalar(50, 255, 50), -1, CV_AA);
-
-		cv::putText(bgrMat, std::to_string(markers[i].id), center, cv::FONT_HERSHEY_DUPLEX, 2, cv::Scalar(255, 255, 255), 5, CV_AA);
-		cv::putText(bgrMat, std::to_string(markers[i].id), center, cv::FONT_HERSHEY_DUPLEX, 2, cv::Scalar(50, 50, 255), 2, CV_AA);
-	}
-	vector<int> compressionParams = { CV_IMWRITE_PNG_COMPRESSION, 0 };
-	cv::imwrite(path, bgrMat, compressionParams);
+  auto marker_image = drawMarkers(image, markers);
+  vector<int> compressionParams = { CV_IMWRITE_PNG_COMPRESSION, 0 };
+  cv::imwrite(path, marker_image, compressionParams);
 }
 
 

--- a/src/Stag.cpp
+++ b/src/Stag.cpp
@@ -253,4 +253,11 @@ Mat Stag::createMatFromPolarCoords(double radius, double radians, double circleR
 	return point;
 }
 
+cv::Mat Stag::drawMarkers() {
+  return drawer.drawMarkers(image, markers);
+}
+vector<Marker> Stag::getMarkerList() const {
+  return markers;
+}
+
 } // namespace stag


### PR DESCRIPTION
The utility methods to `getMarkerList` and `drawMarkers` were in [stag_ros](https://github.com/aica-technology/stag_ros/tree/ros2-devel) but not here, and they are quite necessary / useful respectively to make the high-level detection interface easier to use.

I also marked it as a shared library so it's easier to link later.

Tested with a downstream package and it worked as expected