### PR TITLE
Exit on error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 mkdir build && cd build || exit 1
-cmake .. && make && make install
+cmake .. && make && make install || exit 1
 cd .. || exit 1
 rm -r build


### PR DESCRIPTION
Failing to build does not raise an error which then fails silently downstream.